### PR TITLE
feature(rule): Allow public access to validation array

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -43,6 +43,11 @@ abstract class Rule
         $this->validation = $validation;
     }
 
+    public function getValidation()
+    {
+        return $this->validation;
+    }
+
     /**
      * Set key
      *


### PR DESCRIPTION
This is specifically useful for callbacks where Rule is bound to the closure. As private/protected properties are not accessible in bound closures.